### PR TITLE
Fix generateCacheKey with different layers

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -16,10 +16,12 @@ function parseRequiredString(requiredString) {
 }
 
 function generateCacheKey(required, currentPath, layers) {
+    const layersCache = loaderUtils.getHashDigest(layers.toString());
     const currentLayerIndex = getCurrentLayerIndex(currentPath, layers);
     const currentLayer = layers[currentLayerIndex];
     const requiredFile = path.join(required.component, currentLayer.files.main);
-    const result = currentLayerIndex + '#' + required.component + JSON.stringify(required.opts);
+    const result = layersCache + '-' + currentLayerIndex +
+        '#' + required.component + JSON.stringify(required.opts);
 
     if (currentPath.length - currentPath.lastIndexOf(requiredFile) === requiredFile.length) {
         return result + currentPath;


### PR DESCRIPTION
I don't know how to write test in current test environment. But you can reproduce bug with this webpack config:

``` javascript
const bundles = ['', 'other'];

export default bundles.map((bundleName) => {
    const layers = [
        {
            path: path.resolve('src/components/'),
            files: {
                main: 'index.js',
                styles: 'styles.less'
            }
        }
    ];

    if (bundleName) {
        layers.push({
            path: path.resolve(`src/${bundleName}/components/`),
            files: {
                main: 'index.js',
                styles: 'styles.less'
            }
        });
    }

    return {
        ...webpackCommonConfig,
        entry: {
            [bundleName ? `app.${bundleName}` : 'app']: './src/index'
        },
        module: {
            preLoaders: [
                {
                    test: /\.js$/,
                    loader: 'rebem-layers-loader',
                    query: {
                        layers,
                        include: [
                            path.resolve('src/index')
                        ]
                    }
                }
            ]
        }
    };
});
```
